### PR TITLE
fix: correct typos in hymn titles

### DIFF
--- a/src/app/pages/hymn-list/hymn-list.page.html
+++ b/src/app/pages/hymn-list/hymn-list.page.html
@@ -1,7 +1,7 @@
 <ion-header class="ion-no-border">
   <ion-toolbar color="primary">
     <ion-title class="ion-text-center ion-padding-top">
-      <h1 class="title-text">Aninnisn Ngunuk</h1>
+      <h1 class="title-text">Kounún Mwareiti</h1>
     </ion-title>
     <ion-buttons slot="end">
       <ion-button [routerLink]="['/about']" fill="clear">

--- a/src/app/pages/splash/splash.page.html
+++ b/src/app/pages/splash/splash.page.html
@@ -15,7 +15,7 @@
              
       </object>
       <h1 style="color: #f4c430; font-size: 30px; font-weight: 700;">Kounún Mwareiti</h1>
-      <p style="color: #f4c430; font-size: 20px; font-weight: bold;"> Song of Prise</p>
+      <p style="color: #f4c430; font-size: 20px; font-weight: bold;">Songs of Praise</p>
       
     </div>
 


### PR DESCRIPTION
- Change "Song of Prise" to "Songs of Praise" in splash page
- Update "Aninnisn Ngunuk" to "Kounún Mwareiti" in hymn list page